### PR TITLE
List Roles Converter

### DIFF
--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -44,6 +44,8 @@ from typing import (
     TypeVar,
     Union,
     runtime_checkable,
+    get_origin,
+    get_args,
 )
 import types
 
@@ -1519,7 +1521,7 @@ CONVERTER_MAPPING: Dict[type, Any] = {
     discord.GuildSticker: GuildStickerConverter,
     discord.ScheduledEvent: ScheduledEventConverter,
     discord.ForumChannel: ForumChannelConverter,
-    List[discord.Role]: RolesConverter
+    List[discord.Role]: RolesConverter,
 }
 
 
@@ -1535,7 +1537,12 @@ async def _actual_conversion(ctx: Context[BotT], converter: Any, argument: str, 
         if module is not None and (module.startswith('discord.') and not module.endswith('converter')):
             converter = CONVERTER_MAPPING.get(converter, converter)
 
+    origin = get_origin(converter)
+    if origin and (mapped_converter := CONVERTER_MAPPING.get(converter)):
+        converter = mapped_converter
+
     try:
+
         if inspect.isclass(converter) and issubclass(converter, Converter):
             if inspect.ismethod(converter.convert):
                 return await converter.convert(ctx, argument)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -809,18 +809,14 @@ class RoleConverter(IDConverter[discord.Role]):
         for choice in choices:
             choice_name = choice.name.lower()
 
-            # Exact match
             if query_lower == choice_name:
                 return choice
 
-            # Check for substring match
             if query_lower in choice_name:
                 return choice
 
             score = self.word_match_score(query_lower, choice_name)
             distance = self.normalized_levenshtein(query_lower, choice_name)
-
-            _log.info(f"Comparing '{query_lower}' to '{choice_name}': Score={score}, Distance={distance}")
 
             if (score > best_score) or (score == best_score and distance < min_distance):
                 best_score = score
@@ -1484,6 +1480,7 @@ def is_generic_type(tp: Any, *, _GenericAlias: type = _GenericAlias) -> bool:
     return isinstance(tp, type) and issubclass(tp, Generic) or isinstance(tp, _GenericAlias)
 
 
+# TODO: List[discord.Role] should return a list of role from an example input like "admin, mod, team"
 CONVERTER_MAPPING: Dict[type, Any] = {
     discord.Object: ObjectConverter,
     discord.Member: MemberConverter,

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -1651,11 +1651,7 @@ async def run_converters(ctx: Context[BotT], converter: Any, argument: str, para
 
         raise BadLiteralArgument(param, literal_args, errors, argument)
 
-    if origin is not None and is_generic_type(converter):
-        mapped_converter = CONVERTER_MAPPING.get(converter)
-        if not mapped_converter:
-            converter = origin
-        else:
-            converter = mapped_converter
+    if origin and is_generic_type(converter):
+        converter = CONVERTER_MAPPING.get(converter, origin)
 
     return await _actual_conversion(ctx, converter, argument, param)

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -782,6 +782,8 @@ class RoleConverter(IDConverter[discord.Role]):
         if not guild:
             raise NoPrivateMessage()
 
+        result = None
+
         if len(argument.split(',')) > 1:
             results: List[discord.Role] = []
             # Limit to a max of 25 roles to prevent abuse

--- a/discord/ext/commands/converter.py
+++ b/discord/ext/commands/converter.py
@@ -802,16 +802,6 @@ class RoleConverter(IDConverter[discord.Role]):
         match = self._get_id_match(argument) or re.match(r'<@&([0-9]{15,20})>$', argument)
         if match:
             result = guild.get_role(int(match.group(1)))
-        else:
-            await guild.fetch_roles()
-            result = next(
-                (
-                    role
-                    for role in sorted(guild.roles, key=lambda role: role.position, reverse=True)
-                    if argument.lower() in role.name.lower()
-                ),
-                None,
-            )
 
         if result is None:
             # If no exact match is found, attempt a fuzzy search

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -428,7 +428,6 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
 
         self.brief: Optional[str] = kwargs.get('brief')
         self.usage: Optional[str] = kwargs.get('usage')
-        self.example: Optional[str] = kwargs.get('example')
         self.rest_is_raw: bool = kwargs.get('rest_is_raw', False)
         self.aliases: Union[List[str], Tuple[str]] = kwargs.get('aliases', [])
         self.extras: Dict[Any, Any] = kwargs.get('extras', {})

--- a/discord/ext/commands/core.py
+++ b/discord/ext/commands/core.py
@@ -431,6 +431,7 @@ class Command(_BaseCommand, Generic[CogT, P, T]):
         self.rest_is_raw: bool = kwargs.get('rest_is_raw', False)
         self.aliases: Union[List[str], Tuple[str]] = kwargs.get('aliases', [])
         self.extras: Dict[Any, Any] = kwargs.get('extras', {})
+        self.example: Optional[str] = kwargs.get('example')
 
         self._flag: Optional[FlagConverter] = kwargs.get('flag')
 


### PR DESCRIPTION
## Summary

RolesConverter converts to a list of roles, instead of a singular role.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new `RolesConverter` class for converting strings to lists of roles and enhance the `RoleConverter` with fuzzy search capabilities. Refactor the `run_converters` function to improve handling of generic types.

New Features:
- Introduce a new `RolesConverter` class that converts a string to a list of `discord.Role` objects, supporting lookups by ID, mention, and name with fuzzy search and ranking.

Enhancements:
- Enhance the `RoleConverter` class to include fuzzy search capabilities using Levenshtein distance and word match scoring for more accurate role name matching.
- Refactor the `run_converters` function to handle generic types more effectively by utilizing a mapping for converters.

<!-- Generated by sourcery-ai[bot]: end summary -->